### PR TITLE
expand library type in vidarrbuild file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.8 -2024-04-10
+- Expand librray type in vidarrbuild file
+
 ## 1.0.7 - 2024-04-03
 - Update subworkflows bamQC and bwaMem to new version
 

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -1,7 +1,8 @@
 {
     "names": [
         "umiCollapse_TS",
-	"umiCollapse_CM"
+        "umiCollapse_CM",
+        "umiCollapse"
     ],
     "wdl": "umiCollapse.wdl"
 }


### PR DESCRIPTION
umiCollapse was configured in vidarr to have two library type CM and TS, not combined with umiQC I assume we need expand library type